### PR TITLE
[BUGFIX] Replaced Long method with Integer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ notifications:
 
 env:
   global:
-    - PROVIDER_VERSION=2.0.7
+    - PROVIDER_VERSION=2.0.8
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.parabot.servers</groupId>
     <artifactId>317-api-minified-dreamscape</artifactId>
-    <version>2.0.7</version>
+    <version>2.0.8</version>
     <name>Parabot 317-API-Minified Dreamscape</name>
 
     <licenses>

--- a/src/main/java/org/rev317/min/api/methods/Menu.java
+++ b/src/main/java/org/rev317/min/api/methods/Menu.java
@@ -34,7 +34,6 @@ public class Menu {
      *
      * @param object
      * @param actionIndex
-     *
      * @deprecated
      */
     public static void interact(SceneObject object, int actionIndex) {
@@ -88,7 +87,6 @@ public class Menu {
      *
      * @param character
      * @param actionIndex
-     *
      * @deprecated
      */
     public static void interact(Character character, int actionIndex) {
@@ -131,7 +129,6 @@ public class Menu {
      * @param item
      * @param actionIndex
      * @param interfaceParentId
-     *
      * @deprecated
      */
     public static void transformItem(Item item, int actionIndex, int interfaceParentId) {
@@ -181,7 +178,6 @@ public class Menu {
      *
      * @param item
      * @param action
-     *
      * @deprecated
      */
     public static void interact(GroundItem item, int action) {

--- a/src/main/java/org/rev317/min/api/methods/Skill.java
+++ b/src/main/java/org/rev317/min/api/methods/Skill.java
@@ -32,7 +32,7 @@ public enum Skill {
     SUMMONING,
     DUNGEONEERING;
 
-    private static final long[] EXPERIENCE = {
+    private static final int[] EXPERIENCE = {
             0, 0, 83, 174, 276, 388, 512, 650, 801, 969, 1154, 1358, 1584,
             1833, 2107, 2411, 2746, 3115, 3523, 3973, 4470, 5018, 5624, 6291,
             7028, 7842, 8740, 9730, 10824, 12031, 13363, 14833, 16456, 18247,
@@ -51,13 +51,12 @@ public enum Skill {
             280681209, 309897078, 342154009, 377768545, 417090179, 460504778,
             508438379, 561361362, 619793069, 684306901, 755535943, 834179178,
             921008346, 1016875516, 1122721449, 1239584831, 1368612462, 1511070513,
-            1668356950, 1842015252, 2033749558 };
+            1668356950, 1842015252, 2033749558};
 
     /**
      * Returns the experience of the provided skill.
      *
      * @param index the skill index.
-     *
      * @return the experience.
      */
     public static final int getCurrentExperience(int index) {
@@ -68,7 +67,6 @@ public enum Skill {
      * Returns the real level of the provided skill.
      *
      * @param index the skill index.
-     *
      * @return the real skill level.
      */
     public static final int getRealLevel(int index) {
@@ -79,7 +77,6 @@ public enum Skill {
      * Returns the current level of the provided skill. (Will return de-buffed/buffed levels)
      *
      * @param index the skill index.
-     *
      * @return the current skill level. Done by Bears
      */
     public static final int getCurrentLevel(int index) {
@@ -90,10 +87,9 @@ public enum Skill {
      * Returns the exact experience at the provided level.
      *
      * @param level the level.
-     *
      * @return the experience at the provided level.
      */
-    public static final long getExperienceByLevel(int level) {
+    public static final int getExperienceByLevel(int level) {
         if (level > 150 || level < 1) {
             return 0;
         }
@@ -105,7 +101,6 @@ public enum Skill {
      * Returns the exact level with the provided experience.
      *
      * @param experience the experience.
-     *
      * @return the level at the provided experience.
      */
     public static final int getLevelByExperience(int experience) {
@@ -122,10 +117,9 @@ public enum Skill {
      * Returns the remaining experience for the provided skill to level up.
      *
      * @param index the skill index.
-     *
      * @return the remaining experience.
      */
-    public static final long getRemainingExperience(int index) {
+    public static final int getRemainingExperience(int index) {
         int level = getLevelByExperience(getCurrentExperience(index));
         if (level > 150 || level < 1) {
             return 0;
@@ -138,12 +132,11 @@ public enum Skill {
      * Returns the percentage to the next level for the provided skill.
      *
      * @param index the skill index.
-     *
      * @return the remaining percentage.
      */
     public static final int getPercentToNextLevel(int index) {
         int currentLevel = getLevelByExperience(getCurrentExperience(index));
-        int nextLevel    = currentLevel + 1;
+        int nextLevel = currentLevel + 1;
         if (currentLevel == 150 || nextLevel > 150 || currentLevel < 1
                 || nextLevel < 1) {
             return 0;
@@ -191,7 +184,7 @@ public enum Skill {
     /**
      * Returns the remaining experience until the next level.
      */
-    public final long getRemaining() {
+    public final int getRemaining() {
         return Skill.getRemainingExperience(this.ordinal());
     }
 

--- a/src/main/java/org/rev317/min/api/wrappers/SceneObject.java
+++ b/src/main/java/org/rev317/min/api/wrappers/SceneObject.java
@@ -12,14 +12,14 @@ import org.rev317.min.api.methods.SceneObjects;
  * @author Everel
  */
 public class SceneObject implements Locatable {
-    public static final int TYPE_WALL             = 0; // object1
-    public static final int TYPE_WALLDECORATION   = 1; // object2
+    public static final int TYPE_WALL = 0; // object1
+    public static final int TYPE_WALLDECORATION = 1; // object2
     public static final int TYPE_GROUNDDECORATION = 2; // object3
-    public static final int TYPE_GROUNDITEM       = 3; // object4
-    public static final int TYPE_INTERACTIVE      = 4; // object5
+    public static final int TYPE_GROUNDITEM = 3; // object4
+    public static final int TYPE_INTERACTIVE = 4; // object5
 
-    public  SceneObjectTile accessor;
-    private int             type;
+    public SceneObjectTile accessor;
+    private int type;
 
     public SceneObject(SceneObjectTile accessor, int type) {
         this.accessor = accessor;
@@ -102,7 +102,6 @@ public class SceneObject implements Locatable {
      * Interacts with this object
      *
      * @param actionIndex
-     *
      * @deprecated
      */
     public void interact(int actionIndex) {


### PR DESCRIPTION
Methods couldn't be accessed because the Minified API uses `int` instead of `long`.
Would throw `Exception in thread "Thread-13" java.lang.NoSuchMethodError: org.rev317.min.api.methods.Skill.getRemaining()I`
Also formatted the code.